### PR TITLE
Fix layout glitch

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4,7 +4,8 @@
 .__github-wiki-live-edit__ .container {
   width: auto;
 }
-.__github-wiki-live-edit__ .header,
+.__github-wiki-live-edit__ .Header,
+.__github-wiki-live-edit__ .footer,
 .__github-wiki-live-edit__ .gh-header-actions a[href$='_new'],
 .__github-wiki-live-edit__ .pagehead,
 .__github-wiki-live-edit__ .comment-form-head,
@@ -27,6 +28,9 @@
 .__github-wiki-live-edit__ #gollum-editor-help {
   position: relative;
   margin-top: 10px;
+}
+.__github-wiki-live-edit__ .gollum-editor {
+  position: relative;
 }
 .__github-wiki-live-edit__ .gollum-editor,
 .__github-wiki-live-edit__ .gollum-editor-function-bar,
@@ -57,7 +61,7 @@
 .__github-wiki-live-edit__ .previewable-comment-form .preview-content {
   float: right;
   position: relative;
-  overflow: scroll;
+  overflow: auto;
 }
 .__github-wiki-live-edit__ .wiki-wrapper .wiki-content .previewable-comment-form.preview-selected .preview-content {
   padding-left: 24px;
@@ -79,7 +83,7 @@
 }
 .__github-wiki-live-edit__ #gollum-editor-edit-summary {
   position: absolute;
-  top: 73px;
+  top: 0;
   left: 50%;
   box-sizing: border-box;
   width: 50%;
@@ -91,8 +95,8 @@
 }
 .__github-wiki-live-edit__ .form-actions {
   position: absolute;
-  top: 73px;
-  right: 30px;
+  top: 0;
+  right: 0;
 }
 .__github-wiki-live-edit__ .new-discussion-timeline .previewable-comment-form .comment-body {
   padding: 0;

--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -63,7 +63,7 @@ function applyStyle() {
   body.appendChild(style);
   body.classList.add(CLASS_NAME);
 
-  editorSummary.style.paddingRight = (40 + editorSubmit.offsetWidth) + "px";
+  editorSummary.style.paddingRight = (10 + editorSubmit.offsetWidth) + "px";
 }
 
 function removeStyle() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Github Wiki LiveEdit",
   "description": "Adding live editing features into Github wiki.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "background": {
     "scripts": ["js/background.js"]
   },


### PR DESCRIPTION
Hi,
First of all, a heartfelt thank you for the useful extension!

This PR fixes some layout glitches due to GitHub's CSS updates.

- Hide the global header and footer.
- Position the "edit summary" input and the "Save" button properly.
- Make scroll bars of the preview area "auto".

<img width="1228" alt="setenv wiki-180220" src="https://user-images.githubusercontent.com/45791/36405371-ae4fd878-1633-11e8-82f4-b74da2eebbd0.png">
